### PR TITLE
Add format_prompt tests and CI

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,25 @@
+name: Python package
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: Run tests
+      run: |
+        pytest -vv

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ langchain-core>=0.1.0
 pydantic>=2.5.2
 tenacity>=8.2.3
 openai>=1.3.7
+pytest>=7.4.0

--- a/tests/test_prepare_dataset.py
+++ b/tests/test_prepare_dataset.py
@@ -1,0 +1,29 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import types
+# Stub external dependencies used in prepare_dataset
+sys.modules['datasets'] = types.ModuleType('datasets')
+sys.modules['datasets'].Dataset = object
+sys.modules['datasets'].load_dataset = lambda *args, **kwargs: None
+sys.modules['pandas'] = types.ModuleType('pandas')
+sys.modules['pandas'].DataFrame = object
+
+from prepare_dataset import format_prompt
+
+
+def test_format_prompt_default():
+    example = {"input": "Hello", "output": "World"}
+    formatted = format_prompt(example)
+    assert formatted == {"input": "Hello\n\n### Response:", "output": "World"}
+
+
+def test_format_prompt_with_custom_dict_template():
+    example = {"input": "What is AI?", "output": "Artificial Intelligence."}
+    template = {
+        "system": "You are a helpful assistant.",
+        "user": "Question: {input}",
+        "assistant": "Answer: {output}",
+    }
+    formatted = format_prompt(example, prompt_template=template)
+    expected_input = "You are a helpful assistant.\n\nQuestion: What is AI?"
+    assert formatted == {"input": expected_input, "output": "Artificial Intelligence."}


### PR DESCRIPTION
## Summary
- add `pytest` as a requirement
- test `format_prompt` with and without a template
- run tests in GitHub Actions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840cb9bd2c88330ab8dad2fe72d9f46