### PR TITLE
Set GPT-4o as evaluation default

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ A comprehensive machine learning pipeline for fine-tuning and evaluating Qwen la
 ## Features
 
 - QLoRA fine-tuning for Qwen/Qwen2.5-0.5B-Instruct model
-- GPT-4 based evaluation system
+- GPT-4o based evaluation system
 - Comprehensive metrics tracking
 - Batch processing support
 - Detailed logging and analysis
@@ -151,7 +151,7 @@ EVALUATION_DIR=evaluation
 
 ## Evaluation System
 
-The evaluation system uses GPT-4 to assess model outputs across multiple dimensions:
+The evaluation system uses GPT-4o to assess model outputs across multiple dimensions:
 
 - Relevance Score (0-10)
 - Completeness Score (0-10)

--- a/eval.py
+++ b/eval.py
@@ -14,7 +14,7 @@ from pydantic import BaseModel, Field
 load_dotenv()
 
 # Get environment variables
-EVAL_MODEL = os.getenv('EVAL_MODEL', 'gpt-4')
+EVAL_MODEL = os.getenv('EVAL_MODEL', 'gpt-4o')
 EVAL_TEMPERATURE = float(os.getenv('EVAL_TEMPERATURE', '0.0'))
 EVAL_MAX_TOKENS = int(os.getenv('EVAL_MAX_TOKENS', '1000'))
 ROOT_DIR = os.getenv('ROOT_DIR', '.')
@@ -65,7 +65,7 @@ class EvaluationMetrics(BaseModel):
 
 class ModelEvaluator:
     def __init__(self, model_name: str = EVAL_MODEL, temperature: float = EVAL_TEMPERATURE):
-        """Initialize the evaluator with GPT-4"""
+        """Initialize the evaluator with GPT-4o"""
         self.evaluator = ChatOpenAI(
             model=model_name,
             temperature=temperature,
@@ -227,7 +227,7 @@ Provide a detailed evaluation following the specified metrics."""
 def main():
     """Main function to run evaluation"""
     import argparse
-    parser = argparse.ArgumentParser(description='Evaluate model predictions using GPT-4')
+    parser = argparse.ArgumentParser(description='Evaluate model predictions using GPT-4o')
     parser.add_argument('--predictions', type=str, required=True,
                       help='Path to predictions JSON file')
     parser.add_argument('--reference', type=str, required=True,


### PR DESCRIPTION
## Summary
- make GPT-4o the default model for evaluation
- update comments and CLI help message in `eval.py`
- document GPT-4o usage in README

## Testing
- `python -m py_compile eval.py`
- `python eval.py --help` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6840cb8dc4b48330b35cd3df612425f1